### PR TITLE
Move 'auto-optimise-store' out of extraOptions

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -201,12 +201,10 @@ in {
   };
 
   nix = {
+    autoOptimiseStore = true;
     gc = {
       automatic = true;
     };
-    extraOptions = ''
-      auto-optimise-store = true
-    '';
     trustedBinaryCaches = [ "http://ci.hcweb.aws.hc.lan:8081" ];
     requireSignedBinaryCaches = false;
   };


### PR DESCRIPTION
With the old configuration, the option ends up being declared twice in `nix.conf`. After this change, it is only declared once with the correct value.